### PR TITLE
Only listen to the fullscreen-events of one of the different vendor

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -330,17 +330,17 @@ VRDisplay.prototype.addFullscreenListeners_ = function(element, changeHandler, e
   this.fullscreenErrorHandler_ = errorHandler;
 
   if (changeHandler) {
-    element.addEventListener('fullscreenchange', changeHandler, false);
-    element.addEventListener('webkitfullscreenchange', changeHandler, false);
-    document.addEventListener('mozfullscreenchange', changeHandler, false);
-    element.addEventListener('msfullscreenchange', changeHandler, false);
+    if (document.fullscreenEnabled) element.addEventListener('fullscreenchange', changeHandler, false);
+	  else if (document.webkitFullscreenEnabled) element.addEventListener('webkitfullscreenchange', changeHandler, false);
+	  else if (document.mozFullscreenEnabled) document.addEventListener('mozfullscreenchange', changeHandler, false);
+	  else if (document.msFullscreenEnabled) element.addEventListener('msfullscreenchange', changeHandler, false);
   }
 
   if (errorHandler) {
-    element.addEventListener('fullscreenerror', errorHandler, false);
-    element.addEventListener('webkitfullscreenerror', errorHandler, false);
-    document.addEventListener('mozfullscreenerror', errorHandler, false);
-    element.addEventListener('msfullscreenerror', errorHandler, false);
+    if (document.fullscreenEnabled) element.addEventListener('fullscreenerror', errorHandler, false);
+	  else if (document.webkitFullscreenEnabled) element.addEventListener('webkitfullscreenerror', errorHandler, false);
+	  else if (document.mozFullscreenEnabled) document.addEventListener('mozfullscreenerror', errorHandler, false);
+	  else if (document.msFullscreenEnabled) element.addEventListener('msfullscreenerror', errorHandler, false);
   }
 };
 


### PR DESCRIPTION
Without doing this, it can happen that the handlers are called via the 'fullscreenchange' and 'webkitfullscreenchange' event when using the 'Fullscreen-API-Polyfill' (https://github.com/neovov/Fullscreen-API-Polyfill). So it is best to only listen to one of the events, otherwise the handler may be called several times which lead to nothing being presented.
